### PR TITLE
adding some policies for conftest

### DIFF
--- a/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
+++ b/gcp/gke/gke-terraform-scripts/modules/kubernetes/main.tf
@@ -33,16 +33,14 @@ resource "google_container_cluster" "gke-cluster" {
  network = var.vpc_name
 
  network_policy {
-  enabled = true
+  enabled = false
  }
 
  private_cluster_config {
-  enable_private_nodes = true
+  enable_private_nodes = false
   enable_private_endpoint = true
   master_ipv4_cidr_block = var.master_cidr
  }
-
-
 
  vertical_pod_autoscaling {
   enabled = true

--- a/policy/appendix.rego
+++ b/policy/appendix.rego
@@ -1,0 +1,21 @@
+package main
+
+deny[msg] {
+    proto := input.resource.aws_alb_listener[lb].protocol
+    proto == "HTTP"
+    msg = sprintf("ALB `%v` is using HTTP rather than HTTPS", [lb])
+}
+
+deny[msg] {
+    rule := input.resource.aws_security_group_rule[name]
+    rule.type == "ingress"
+    contains(rule.cidr_blocks[_], "0.0.0.0/0") 
+    msg = sprintf("ASG `%v` defines a fully open ingress", [name])
+}
+
+deny[msg] {
+    disk = input.resource.azurerm_managed_disk[name]
+    has_field(disk, "encryption_settings")
+    disk.encryption_settings.enabled != true
+    msg = sprintf("Azure disk `%v` is not encrypted", [name])
+}

--- a/policy/gke.rego
+++ b/policy/gke.rego
@@ -1,0 +1,18 @@
+package main
+
+has_field(obj, field) {
+    obj[field]
+}
+
+warn[msg] {
+    np := input.resource.google_container_cluster[gke].network_policy
+    np.enabled == false
+    msg = sprintf("GKE cluster `%v` network policy needs to be enabled", [gke])
+}
+
+deny[msg] {
+    pcc := input.resource.google_container_cluster[gke]
+    has_field(pcc, "private_cluster_config")
+    pcc.private_cluster_config.enable_private_nodes == false
+    msg = sprintf("GKE cluster `%v` private nodes are not enabled", [gke])
+}


### PR DESCRIPTION
@eddie-knight and @leefaus worked on some policies based on the existing GKE Terraform scripts already created to do some validations.  To test that these policies work you should follow these steps:

```bash
> git clone https://github.com/leefaus/cloud-service-certification.git

> cd cloud-service-certification

> docker run --rm -v $(pwd):/project openpolicyagent/conftest test modules/kubernetes/main.tf
```

Also check the diffs to see that I made some changes so we could see the test actually fail.