### PR TITLE
Only run terraform check when we change the relevant files

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,9 +1,21 @@
 name: terraform fmt check
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    paths:
+      - ".github/workflows/terraform.yml"
+      - "**/*terraform*/**"
+      - "**.tf"
+      - "**.tfvars"
+      - "!**.md"
+  pull_request:
+    paths:
+      - ".github/workflows/terraform.yml"
+      - "**/*terraform*/**"
+      - "**.tf"
+      - "**.tfvars"
+      - "!**.md"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Somewhat self-explanatory. While it currently doesn't cost us much, there are cases where we obviously don't need to run the workflow: for example when a PR adds a new text document. As such I've set the patterns we care about for determining whether the terraform formatting checks are run.