### PR TITLE
Add new eks terraform deployment check

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -1,0 +1,12 @@
+name: terraform apply
+
+runs:
+  using: "composite"
+  steps:
+    - name: Terraform Init
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      shell: bash
+
+    - name: Terraform Apply
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} apply -auto-approve
+      shell: bash

--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -1,12 +1,16 @@
 name: terraform apply
 
+inputs:
+  working-directory:
+    required: true
+
 runs:
   using: "composite"
   steps:
     - name: Terraform Init
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      run: terraform -chdir=${{ inputs.working-directory }} init
       shell: bash
 
     - name: Terraform Apply
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} apply -auto-approve
+      run: terraform -chdir=${{ inputs.working-directory }} apply -auto-approve
       shell: bash

--- a/.github/actions/terraform-destroy/action.yml
+++ b/.github/actions/terraform-destroy/action.yml
@@ -1,0 +1,12 @@
+name: terraform destroy
+
+runs:
+  using: "composite"
+  steps:
+    - name: Terraform Init
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      shell: bash
+
+    - name: Terraform Destroy
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} destroy -auto-approve
+      shell: bash

--- a/.github/actions/terraform-destroy/action.yml
+++ b/.github/actions/terraform-destroy/action.yml
@@ -1,12 +1,16 @@
 name: terraform destroy
 
+inputs:
+  working-directory:
+    required: true
+
 runs:
   using: "composite"
   steps:
     - name: Terraform Init
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      run: terraform -chdir=${{ inputs.working-directory }} init
       shell: bash
 
     - name: Terraform Destroy
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} destroy -auto-approve
+      run: terraform -chdir=${{ inputs.working-directory }} destroy -auto-approve
       shell: bash

--- a/.github/actions/terraform-validate/action.yml
+++ b/.github/actions/terraform-validate/action.yml
@@ -1,16 +1,20 @@
 name: terraform validate
 
+inputs:
+  working-directory:
+    required: true
+
 runs:
   using: "composite"
   steps:
     - name: Terraform Init
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      run: terraform -chdir=${{ inputs.working-directory }} init
       shell: bash
 
     - name: Terraform Format
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} fmt -check -recursive
+      run: terraform -chdir=${{ inputs.working-directory }} fmt -check -recursive
       shell: bash
 
     - name: Terraform Validate
-      run: terraform ${{ env.TF_GLOBAL_ARGS }} validate
+      run: terraform -chdir=${{ inputs.working-directory }} validate
       shell: bash

--- a/.github/actions/terraform-validate/action.yml
+++ b/.github/actions/terraform-validate/action.yml
@@ -1,0 +1,16 @@
+name: terraform validate
+
+runs:
+  using: "composite"
+  steps:
+    - name: Terraform Init
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} init
+      shell: bash
+
+    - name: Terraform Format
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} fmt -check -recursive
+      shell: bash
+
+    - name: Terraform Validate
+      run: terraform ${{ env.TF_GLOBAL_ARGS }} validate
+      shell: bash

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -35,8 +35,8 @@ jobs:
       run:
         working-directory: aws/eks/eks-terraform-scripts/
     env:
-      AWS_ACCESS_KEY_ID: "TEST_KEY_ID"
-      AWS_SECRET_ACCESS_KEY: "TEST_SECRET_KEY"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     needs: validate
     steps:
       - uses: actions/checkout@v2
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     env:
-      AWS_ACCESS_KEY_ID: "TEST_KEY_ID"
-      AWS_SECRET_ACCESS_KEY: "TEST_SECRET_KEY"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     needs: apply
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -1,0 +1,56 @@
+name: aws eks terraform verification
+
+on:
+  push:
+    paths:
+      - ".github/actions/terraform-*/action.yml"
+      - ".github/workflows/aws-eks-verify.yml"
+      - "aws/eks/eks-terraform-scripts/**"
+      - "!**.md"
+  pull_request:
+    paths:
+      - ".github/actions/terraform-*/action.yml"
+      - ".github/workflows/aws-eks-verify.yml"
+      - "aws/eks/eks-terraform-scripts/**"
+      - "!**.md"
+  workflow_dispatch:
+
+env:
+  TF_IN_AUTOMATION: true
+  TF_INPUT: false
+  TF_CLI_ARGS: "-no-color"
+  TF_GLOBAL_ARGS: "-chdir=aws/eks/eks-terraform-scripts/"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1.3.2
+      - uses: ./.github/actions/terraform-validate
+
+  apply:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aws/eks/eks-terraform-scripts/
+    env:
+      AWS_ACCESS_KEY_ID: "TEST_KEY_ID"
+      AWS_SECRET_ACCESS_KEY: "TEST_SECRET_KEY"
+    needs: validate
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1.3.2
+      - uses: ./.github/actions/terraform-apply
+
+  destroy:
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      AWS_ACCESS_KEY_ID: "TEST_KEY_ID"
+      AWS_SECRET_ACCESS_KEY: "TEST_SECRET_KEY"
+    needs: apply
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1.3.2
+      - uses: ./.github/actions/terraform-destroy

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: hashicorp/setup-terraform@v1.3.2
       - name: Setup kubectl
         uses: azure/setup-kubectl@v1
+      - name: Make sure we have destroyed any leftover resources from previous runs
+        uses: ./.github/actions/terraform-destroy
       - uses: ./.github/actions/terraform-apply
 
   destroy:

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1.3.2
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v1
       - uses: ./.github/actions/terraform-apply
 
   destroy:

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -25,9 +25,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1.3.2
-      - uses: ./.github/actions/terraform-validate
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+      - name: Validate eks terraform
+        uses: ./.github/actions/terraform-validate
 
   apply:
     runs-on: ubuntu-latest
@@ -39,13 +42,16 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     needs: validate
     steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1.3.2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v1.3.2
       - name: Setup kubectl
         uses: azure/setup-kubectl@v1
       - name: Make sure we have destroyed any leftover resources from previous runs
         uses: ./.github/actions/terraform-destroy
-      - uses: ./.github/actions/terraform-apply
+      - name: Apply eks terraform
+        uses: ./.github/actions/terraform-apply
 
   destroy:
     runs-on: ubuntu-latest
@@ -55,6 +61,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     needs: apply
     steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1.3.2
-      - uses: ./.github/actions/terraform-destroy
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v1.3.2
+      - name: Destroy eks terraform
+        uses: ./.github/actions/terraform-destroy

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
 
-  apply:
+  ephemeral-deploy:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,20 +58,8 @@ jobs:
         uses: ./.github/actions/terraform-apply
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
-
-  destroy:
-    runs-on: ubuntu-latest
-    if: always()
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    needs: apply
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@v1.3.2
       - name: Destroy eks terraform
+        if: always()
         uses: ./.github/actions/terraform-destroy
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    outputs:
+      eks-ok: ${{ steps.check-eks-secrets.outputs.eks-ok }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -33,6 +35,12 @@ jobs:
         uses: ./.github/actions/terraform-validate
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: check for secrets needed for eks deploy
+        id: check-eks-secrets
+        run: |
+          if [ ! -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]; then
+            echo "::set-output name=eks-ok::true"
+          fi
 
   ephemeral-deploy:
     runs-on: ubuntu-latest
@@ -43,6 +51,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     needs: validate
+    if: ${{ needs.validate.outputs.eks-ok == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -19,7 +19,7 @@ env:
   TF_IN_AUTOMATION: true
   TF_INPUT: false
   TF_CLI_ARGS: "-no-color"
-  TF_GLOBAL_ARGS: "-chdir=aws/eks/eks-terraform-scripts/"
+  WORKING_DIRECTORY: aws/eks/eks-terraform-scripts
 
 jobs:
   validate:
@@ -31,12 +31,14 @@ jobs:
         uses: hashicorp/setup-terraform@v1.3.2
       - name: Validate eks terraform
         uses: ./.github/actions/terraform-validate
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
 
   apply:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: aws/eks/eks-terraform-scripts/
+        working-directory: ${{ env.WORKING_DIRECTORY }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -50,8 +52,12 @@ jobs:
         uses: azure/setup-kubectl@v1
       - name: Make sure we have destroyed any leftover resources from previous runs
         uses: ./.github/actions/terraform-destroy
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Apply eks terraform
         uses: ./.github/actions/terraform-apply
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
 
   destroy:
     runs-on: ubuntu-latest
@@ -67,3 +73,5 @@ jobs:
         uses: hashicorp/setup-terraform@v1.3.2
       - name: Destroy eks terraform
         uses: ./.github/actions/terraform-destroy
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       eks-ok: ${{ steps.check-eks-secrets.outputs.eks-ok }}
     steps:
@@ -43,7 +43,7 @@ jobs:
           fi
 
   ephemeral-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -3,26 +3,26 @@ name: meeting-minutes-action
 # This GitHub action is used to manage meeting minutes via GitHub Issues:
 # - The issue description contains minutes and other meeting meta info (see .github/ISSUE_TEMPLATE/Meeting.md)
 # - Issue commenters are tracked as meetings attendants, and (eventually, not real time) published on metrics.finos.org
-# 
+#
 # When an issue (with "meeting" label) is closed, this action
 # collects the issue commenters and uses FINOS metadata-tool to generate a CSV
 # file with meeting attendance, which can be submitted for later ingestion and
-# final publication into metrics.finos.org . After successful submission, 
+# final publication into metrics.finos.org . After successful submission,
 # the "indexed" label will be added to the issue.
-# 
-# When the "indexed" label is removed, entries will be removed from the index, 
+#
+# When the "indexed" label is removed, entries will be removed from the index,
 # allowing to amend attendance after the meeting; by re-adding the "indexed", entries will be added again to the index.
 #
 # The date of the meeting is extracted from the date that the issue was closed, therefore:
 # - Do not apply the "indexed" label if the issue is not closed
 # - Only close the issue once, during (or right after) the meeting, regardless of issue contents/comments; use the "indexed" label to trigger a reindexing later on
-# 
+#
 # To run this action, you'll need the following secrets defined in https://github.com/finos/<repo name>/settings/secrets :
 # - FINOS_TOKEN
 # - GIT_CSV_TOKEN
-# 
+#
 # Email help@finos.org to setup the secrets in your repository.
-# 
+#
 # Note. There's a thread regarding org level secrets in GitHub, which may avoid the secret configuration step - https://github.community/t5/GitHub-Actions/Secrets-on-Team-and-Organization-level/td-p/29745
 on:
   issues:
@@ -49,7 +49,7 @@ env:
 jobs:
   submit-meeting-attendance:
     if: contains(github.event.issue.labels.*.name, 'meeting')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checking out metadata-tool
       uses: actions/checkout@v2

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Terraform
-        # Long commit hash of v1.2.1
-        uses: hashicorp/setup-terraform@d22444889af304a44b997011fbabb81ff705a7b4
+        uses: hashicorp/setup-terraform@v1.3.2
 
       - name: Terraform Format
         id: fmt

--- a/aws/eks/eks-terraform-scripts/kubernetes.tf
+++ b/aws/eks/eks-terraform-scripts/kubernetes.tf
@@ -5,15 +5,6 @@
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
+  token                  = data.aws_eks_cluster_auth.cluster.token
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
-    command     = "aws"
-    args = [
-      "eks",
-      "get-token",
-      "--cluster-name",
-      data.aws_eks_cluster.cluster.name
-    ]
-  }
 }


### PR DESCRIPTION
Makes use of composable actions to promote code reuse for later workflows per provider/resource.

Includes a filter similar to https://github.com/finos/cloud-service-certification/pull/148 to ensure we only run the workflow whenever relevant files are changed.

Yet to be solved is how to ensure such workflows are run sequentially. Setting `concurrency` is potentially a no-go as it cancels pending pipelines, with no current way to disable that behaviour.

Part of https://github.com/finos/cloud-service-certification/issues/124.