### PR TITLE
Added probr steps to aws-eks-verify workflow

### DIFF
--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -72,7 +72,7 @@ jobs:
         id: probr
         uses: addnab/docker-run-action@v3
         with:
-          image: eknight/probr:v0.1.1-rc
+          image: eknight/probr:v0.1.1-rc # https://github.com/probr/probr-docker
           options: |
             --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/probr-config.yml,target=/probr/run/config.yml \
             --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
@@ -81,7 +81,7 @@ jobs:
       - name: Generate Probr HTML
         uses: addnab/docker-run-action@v3
         with:
-          image: eknight/probr-view:v0.1.0
+          image: eknight/probr-view:v0.1.0 # https://github.com/probr/view-cucumber-html
           options: |
             	--mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
 

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -67,8 +67,38 @@ jobs:
         uses: ./.github/actions/terraform-apply
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Run Probr Kubernetes CIS Tests
+        id: probr
+        uses: addnab/docker-run-action@v3
+        with:
+          image: eknight/probr:v0.1.1-rc
+          options: |
+            --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/probr-config.yml,target=/probr/run/config.yml \
+            --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
+        continue-on-error: true
+
+      - name: Generate Probr HTML
+        uses: addnab/docker-run-action@v3
+        with:
+          image: eknight/probr-view:v0.1.0
+          options: |
+            	--mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Probr
+          path: /probr/run
+
       - name: Destroy eks terraform
         if: always()
         uses: ./.github/actions/terraform-destroy
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Check Probr Validation Result
+        if: steps.probr.outcome == 'failure'
+        run: |
+          echo Probr did not successfully validate the EKS cluster.
+          echo Please review the Probr artifact for detailed information.
+          exit 1

--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -101,4 +101,4 @@ jobs:
         run: |
           echo Probr did not successfully validate the EKS cluster.
           echo Please review the Probr artifact for detailed information.
-          exit 1
+        # TODO: Add 'exit 1' for failures

--- a/aws/eks/eks-terraform-scripts/probr-config.yml
+++ b/aws/eks/eks-terraform-scripts/probr-config.yml
@@ -1,0 +1,6 @@
+Run:
+  - "kubernetes"
+ServicePacks:
+  Kubernetes:
+    AuthorisedContainerImage: "citihub/probr-probe"
+    UnauthorisedContainerImage: "fixme/bad-image-name"

--- a/aws/eks/eks-terraform-scripts/probr-config.yml
+++ b/aws/eks/eks-terraform-scripts/probr-config.yml
@@ -1,3 +1,12 @@
+#
+# This file is used by the aws-eks-verify workflow
+# The values here are used by the Probr runtime
+# to customize the tests that are executed.
+#
+# As of Nov 2021, the only pack suitable for our
+# EKS validation is the Kubernetes-CIS service pack
+# https://github.com/probr/probr-pack-kubernetes
+#
 Run:
   - "kubernetes"
 ServicePacks:


### PR DESCRIPTION
Probr tests are NOT expected to pass on the first try here. I have disabled the final `exit 1` (failure) within `Check Probr Validation Result` until the EKS cluster is in a fully compliant state.