### PR TITLE
Fixes for CI failures

### DIFF
--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: "~1.0.0"
       - name: Validate eks terraform
         uses: ./.github/actions/terraform-validate
         with:
@@ -55,14 +57,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: "~1.0.0"
+
       - name: Setup kubectl
         uses: azure/setup-kubectl@v1
       - name: Make sure we have destroyed any leftover resources from previous runs
         uses: ./.github/actions/terraform-destroy
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
+
       - name: Apply eks terraform
         uses: ./.github/actions/terraform-apply
         with:
@@ -73,17 +80,15 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: eknight/probr:v0.1.1-rc # https://github.com/probr/probr-docker
-          options: |
-            --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/probr-config.yml,target=/probr/run/config.yml \
-            --mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
+          options: --mount type=bind,source=${{ github.workspace }}/${{ env.WORKING_DIRECTORY }}/probr-config.yml,target=/probr/run/config.yml
+            -v ${{ github.workspace }}/${{ env.WORKING_DIRECTORY }}/run:/probr/run
         continue-on-error: true
 
       - name: Generate Probr HTML
         uses: addnab/docker-run-action@v3
         with:
           image: eknight/probr-view:v0.1.0 # https://github.com/probr/view-cucumber-html
-          options: |
-            	--mount type=bind,source="${{ env.WORKING_DIRECTORY }}"/run,target=/probr/run
+          options: -v ${{ github.workspace }}/${{ env.WORKING_DIRECTORY }}/run:/probr/run
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: "~1.0.0"
 
       - name: Terraform Format
         id: fmt

--- a/aws/eks/eks-terraform-scripts/eks-cluster.tf
+++ b/aws/eks/eks-terraform-scripts/eks-cluster.tf
@@ -4,6 +4,7 @@ resource "aws_kms_key" "eks" {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
+  version         = ">=17.0.0, <18.0.0"
   cluster_name    = local.cluster_name
   cluster_version = "1.18"
   subnets         = module.vpc.private_subnets

--- a/aws/eks/eks-terraform-scripts/versions.tf
+++ b/aws/eks/eks-terraform-scripts/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "3.63.0"
     }
 
     random = {
@@ -27,9 +27,9 @@ terraform {
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0.1"
+      version = "2.6.1"
     }
   }
 
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
At some point we'll want to update our dependencies to the latest versions and modify our terraform to work with them, but for now i've locked them to known working versions.

- Fix invalid yaml - due to using multiline syntax with only a single line
- Lock terraform version to 1.0.x
- Lock eks' terraform aws versions.  Important one is `hashicorp/aws` needs to be <= `3.63.0`
- Lock eks' terraform module version, as 18.x needs the above to be `>3.64.0`
- Probr's volume setup wasn't working correctly as it needed absolute paths