### PR TITLE
Updated to use Probr container v0.1.3-rc

### DIFF
--- a/.github/workflows/aws-eks-verify.yml
+++ b/.github/workflows/aws-eks-verify.yml
@@ -74,7 +74,7 @@ jobs:
         id: probr
         uses: addnab/docker-run-action@v3
         with:
-          image: eknight/probr:v0.1.2-rc # https://github.com/probr/probr-docker
+          image: eknight/probr:v0.1.3-rc # https://github.com/probr/probr-docker
           options: |
             -v ${{ github.workspace }}/${{ env.PROBR_DIRECTORY }}:/probr/run
             -v ${{ github.workspace }}/${{ env.WORKING_DIRECTORY }}/kubeconfig_cfi-eks:/root/.kube/config


### PR DESCRIPTION
As v0.1.2 was cut with an error still remaining in the AWS handling, I've made changes and created a RC that addresses that issue.