### PR TITLE
OpenSSF automated test documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,7 +36,7 @@ You may review existing services for examples of existing SAAs.
 
 All IaC should live in external repositories that are independently tested and ready for users to import into their own module registries. Initial contributions do not need to be 100% compliant, but a badge or other documentation should be included to demonstrate the module's level of maturity.
 
-A [child module template repository](https://github.com/finos/cfi-terraform-template-child-module) is currently under construction (as of August 2022). This template repo is designed to streamline the creation of compliant Terraform child modules.
+The [child module template repository](https://github.com/finos/cfi-terraform-template-child-module) is designed to streamline the creation of compliant Terraform child modules. This template repo comes with CI tests that will be run automatically when a pull request is made to the respective repo. You may replicate these tests locally by reviewing the CI to see how the tests are installed and executed.
 
 ## Post-Deployment Validation Tests
 


### PR DESCRIPTION
> The project MUST use at least one automated test suite that is publicly released as FLOSS (this test suite may be maintained as a separate FLOSS project). The project MUST clearly show or document how to run the test suite(s) (e.g., via a continuous integration (CI) script or via documentation in files such as BUILD.md, README.md, or CONTRIBUTING.md). [test]